### PR TITLE
[Sample PR] Rendered Top 5 Webinars

### DIFF
--- a/src/components/Webinars/index.js
+++ b/src/components/Webinars/index.js
@@ -28,10 +28,37 @@ function Webinars() {
   // check out the /Landing/index.js for an example of how to access and render the different variables.
   // use this link to see how the API works: https://airtable.com/appWPIPmVSmXaMhey/api/docs#curl/table:videos
 
+  if (webinars.length > 5) {
+    setWebinars(webinars.slice(0, 5));
+  }
+
   return (
     <div>
       <section className="section is-white">
         <Heading>Webinars</Heading>
+        {webinars.length === 0 ? (
+          <div className="box">
+            <div className="content">
+              <p>
+                <strong>No videos yet! Check back later :)</strong>
+              </p>
+            </div>
+          </div>
+        ) : (
+          webinars.map((vid) => (
+            <div className="box" key={vid.id}>
+              <div className="content">
+                <p>
+                  <a href={vid.fields.VideoLink}>
+                    <strong>{vid.fields.Title}</strong>
+                  </a>
+                  <br />
+                  {vid.fields.Description}
+                </p>
+              </div>
+            </div>
+          ))
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary 
#### [What you implemented: Keep it concise and straight to the point.]

Rendered the title and description of the top 5 webinars from the database on the Webinars page in the portal. If there were no webinars, posted a message saying so.

## To test 
#### [Steps to reach your code: Add stuff like "Run `npm install airtable`" here.]

1. Check out the sample-pull-request branch `git checkout sample-pull-request`
2. Run `npm start` in your command line inside the RTCPortal root directory
3. Navigate to the Webinars page: Resources > Webinars
4. See that webinars are displayed

## Test cases 
#### [Test all edge cases and upload screenshots/provide links]

**1. Less than 5:**

![Screen Shot 2020-09-05 at 7 20 49 PM](https://user-images.githubusercontent.com/43911326/92314952-ebefdc00-efac-11ea-9b7f-72bb876065fc.png)

**2. More than 5 (top 5 are picked):**

![Screen Shot 2020-09-05 at 7 12 16 PM](https://user-images.githubusercontent.com/43911326/92314936-b0551200-efac-11ea-89f5-1cab8f130759.png)

**3. No webinars available:**

![Screen Shot 2020-09-05 at 7 11 48 PM](https://user-images.githubusercontent.com/43911326/92314935-afbc7b80-efac-11ea-9701-f1a1cb4b7a3c.png)

**4. No description provided:**

![Screen Shot 2020-09-05 at 7 12 32 PM](https://user-images.githubusercontent.com/43911326/92314937-b0eda880-efac-11ea-9920-a5e1935b7b96.png)

