### PR TITLE
Opportunities: Rendered Featured Opportunities

### DIFF
--- a/src/components/Opportunities/index.js
+++ b/src/components/Opportunities/index.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { withAuthorization } from '../Session';
 import Heading from '../General/Heading';
+import ViewWithTopBorder from '../General/ViewWithTopBorder';
+//import CompanyPartners from '../CompanyPartners/index.js';
 
 function Opportunities() {
   const airtableKey = process.env.REACT_APP_AIRTABLE_API_KEY;
@@ -35,12 +37,47 @@ function Opportunities() {
   return (
     <div>
       <section className="section is-white">
-        <Heading>Opportunities</Heading>
+        <ViewWithTopBorder>
+          <Heading>Featured Opportunities</Heading>
+          <div className="columns is-multiline">
+            {opportunities.length === 0 ? (
+              <div className="box">
+                <div className="content">
+                  <p>
+                    <strong>No Opportunities yet! Check back later! </strong>
+                  </p>
+                </div>
+              </div>
+            ) : (
+              opportunities.filter((role)=> role.fields.Featured).map((role) => (
+                <div className="column is-one-quarter">
+                  <div className="box" key={role.id}>
+                    <img src={role.fields.CompanyLogo[0].thumbnails.small.url}alt="Logo"></img>
+                    <div className="content">
+                      <p>
+                        <a id={role.id} href={'/opportunities/' + role.id}>
+                          <strong>{role.fields.Title}</strong>
+                        </a>
+                        <br />
+                        {role.fields.CompanyName}
+                        <br />
+                        {role.fields.Location}
+                        <br />
+                        {role.fields.Start}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))
+              
+            )}
+          </div>
+        </ViewWithTopBorder>
       </section>
     </div>
   );
 }
-
+//{role.fields.CompanyLogo[0].url} 
 const condition = (authUser) => authUser != null;
 
 export default withAuthorization(condition)(Opportunities);


### PR DESCRIPTION
### Summary
Rendered the featured roles with location, company name, company logo, and start term information on the Opportunities page. If there are no opportunities available, the Featured Opportunities section will contain a message explaining it. 

### To Test

1. Check out the opportunities branch `git checkout opportunities`
2. Run `npm start` in your command line inside the RTCPortal root directory
3. Navigate to the Opportunities page: Resources > Opportunities
4. View displayed opportunities

### Test Cases
**1. No Opportunities Available: displays message**

![Screen Shot 2020-09-22 at 9 48 40 PM](https://user-images.githubusercontent.com/43322456/93957461-52515a00-fd22-11ea-9d32-e4e9188dd506.png)

**2. Opportunities Available: shows featured roles only**
- Each card is sized based on information provided. (i.e. Starbucks Technical Writer role didn't specify start term, so the card is shorter than the others)
- The full and large sized company logos were of varying dimensions by default, so the small sized logo was used. 
- The screenshot was taken while hovering over the Starbucks Technical Writer role. 
- The role name will link to the a more detailed page about the opportunity (Path shown in the bottom left corner of screenshot: /opportunities/role.id )

![Screen Shot 2020-09-22 at 9 47 19 PM](https://user-images.githubusercontent.com/43322456/93957523-76ad3680-fd22-11ea-8beb-a8393109cb32.png)
