### PR TITLE
Webinar

### DIFF
--- a/src/components/Webinars/index.js
+++ b/src/components/Webinars/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { withAuthorization } from '../Session';
 import Heading from '../General/Heading';
+import ViewWithTopBorder from '../General/ViewWithTopBorder';
 
 function Webinars() {
   const airtableKey = process.env.REACT_APP_AIRTABLE_API_KEY;
@@ -39,6 +40,7 @@ function Webinars() {
   return (
     <div>
       <section className="section is-white">
+        <ViewWithTopBorder>
         <Heading>Webinars</Heading>
         {webinars.length === 0 ? (
           <div className="box">
@@ -71,8 +73,10 @@ function Webinars() {
             </div>
           ))
         )}
+      </ViewWithTopBorder>
       </section>
     </div>
+    
   );
 }
 


### PR DESCRIPTION
# Summary
## Adding REACT "TopBorder" Component and Implemented iframe components for videos
Rendered the Video Preview for the top 5 webinars from the database on the Webinars page in the portal. 

## To test
### Steps to reach your code: 
Run npm start in your command line inside the RTCPortal root directory
Navigate to the Webinars page: Resources > Webinars
See that interactive video previews of webinars are displayed

## Test cases
### Have not considered edge cases but will look into edge cases in link parsing (screenshots/provide links)
![image](https://user-images.githubusercontent.com/55526292/95929994-645b7100-0d93-11eb-9fa5-72921ab0bf5f.png)