### PR TITLE
Company partners

### DIFF
--- a/src/components/CompanyPartners/index.js
+++ b/src/components/CompanyPartners/index.js
@@ -3,6 +3,7 @@ import axios from "axios";
 import { withAuthorization } from "../Session";
 import Heading from "../General/Heading";
 import ViewWithTopBorder from "../General/ViewWithTopBorder";
+import colors from '../../constants/RTCColors';
 
 function CompanyPartners() {
   const airtableKey = process.env.REACT_APP_AIRTABLE_API_KEY;
@@ -88,7 +89,7 @@ function CompanyPartners() {
                 <div className="column" key={company.name}>
                   <div
                     className="box has-text-centered"
-                    onMouseEnter={e => e.currentTarget.style.boxShadow = "0 0 5px #888888"}
+                    onMouseEnter={e => e.currentTarget.style.boxShadow = `0 0 5px ${colors.gray}`}
                     onMouseLeave={e => e.currentTarget.style.boxShadow = ""}
                     style={styles.boxStyle}
                   >


### PR DESCRIPTION
**Summary**

- Fixed a bug where resizing of window would make Company Partners box overlap the footer. Works good now 👍 
- Also added a little shadowy effect on hover over Company box

**How to Run**

- Check out company-partners branch: `git checkout company-partners`
- Start it up: `npm run start`
- Navigate to About Us -> Company Partners

**Screenshots**

Resized window: Success
![image](https://user-images.githubusercontent.com/54512506/96658457-82d0e780-1312-11eb-85fd-4256ee445123.png)

A subtle hover effect (shown on Cisco in this image)
![image](https://user-images.githubusercontent.com/54512506/96658770-6aad9800-1313-11eb-9a30-71c9c7baf3c9.png)